### PR TITLE
common SG ingress 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # vscode
 .vscode
+
+# Claude Code
+.claude/
+CLAUDE.md

--- a/terraform/common/dev/services/ec2.tf
+++ b/terraform/common/dev/services/ec2.tf
@@ -31,10 +31,95 @@ resource "aws_security_group" "this" {
   vpc_id      = aws_vpc.this.id
   description = "launch-wizard-1 created 2021-03-05T00:08:18.373+09:00"
 
-  lifecycle {
-    ignore_changes = [
-      ingress,
+  # 호스트/컨테이너에서 실제 listening 중인 포트만 명시.
+  # docker ps + ss -tlnp 로 검증됨 (2026-05-01 기준).
+  # GitHub Actions runner SSH 동적 추가/삭제는 AWS API 직접 호출이라
+  # terraform 이 모르고 지나감 → ignore_changes 불필요.
+
+  ingress {
+    description      = "HTTP (edge-proxy nginx)"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "HTTPS (edge-proxy nginx)"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description = "SSH (admin IPs)"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [
+      "27.142.99.202/32",
+      "119.201.72.35/32",
+      "221.110.31.103/32",
+      "221.149.51.217/32",
+      "13.209.1.56/29", # TODO: 출처 검증 후 제거 또는 유지 결정
     ]
+  }
+
+  ingress {
+    description      = "chatbot-api / chat-service (FastAPI)"
+    from_port        = 8000
+    to_port          = 8000
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "backend-spring-app"
+    from_port        = 8100
+    to_port          = 8100
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "Laravel/Apache (house price prediction)"
+    from_port        = 8200
+    to_port          = 8200
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description      = "go-jwt-web (Apache)"
+    from_port        = 8300
+    to_port          = 8300
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description = "Laravel internal nginx (admin from home IP)"
+    from_port   = 8201
+    to_port     = 8201
+    protocol    = "tcp"
+    cidr_blocks = ["27.143.63.88/32"]
+    self        = true
+  }
+
+  ingress {
+    description = "MySQL (admin from home IP)"
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = ["27.143.63.88/32"]
+    self        = true
   }
 
   egress {


### PR DESCRIPTION
launch-wizard-1 보안그룹의 ingress 를 선언적으로 관리하도록 정리.
호스트(ss -tlnp)와 docker ps 로 실제 listening 포트를 검증한 뒤
사용 중이지 않은 leftover 룰을 제거하고, 중복 룰을 통합함.

- lifecycle.ignore_changes = [ingress] 제거 (GitHub Actions runner SSH 자동 등록은 AWS API 직접 호출이라 terraform 관리 룰과 충돌하지 않음)
- SSH 22: 5개 룰 → 1개로 통합 (CIDR 5개)
- 80/443/8000/8100/8200/8300: IPv4/IPv6 분리 → 포트당 1개로 통합
- 8201 / 3306: 홈 IP + self 분리 → self=true 와 CIDR 통합
- 미사용 포트 제거: 9200, 5601, 9600, 5044, 9500, 8080, 8202, 3000
- 13.209.1.56/29 (AWS Seoul) 는 출처 미확인이라 TODO 주석으로 보존

.gitignore 에 .claude/ , CLAUDE.md 추가 (Claude Code 작업 파일 untrack).

terraform plan: 0 to add, 1 to change, 0 to destroy (in-place update).

## PR의 목적



## 관련URL



## 특이사항

