### PR TITLE
post-merge cleanup: workflow comment 가드 + SG description 보강 + CodeDep…

### DIFF
--- a/.github/workflows/common-dev-apply.yml
+++ b/.github/workflows/common-dev-apply.yml
@@ -60,9 +60,9 @@ jobs:
           fi
 
       # comment
-      # apply 실행후 bot이 커멘트
+      # apply 실행후 PR 이 연결된 경우에만 코멘트 (release 직접 push 시 PR 못 찾으면 스킵)
       - name: comment
-        if: ${{ steps.apply.outcome == 'success' }}
+        if: ${{ steps.apply.outcome == 'success' && steps.findpr.outputs.pr != '' }}
         uses: actions/github-script@v6.1.0
         env:
           APPLY: "terraform¥n${{ steps.apply.outputs.stdout }}"

--- a/.github/workflows/project-dev-apply.yml
+++ b/.github/workflows/project-dev-apply.yml
@@ -62,9 +62,9 @@ jobs:
           fi
 
       # comment
-      # apply 실행후 bot이 커멘트
+      # apply 실행후 PR 이 연결된 경우에만 코멘트 (release 직접 push 시 PR 못 찾으면 스킵)
       - name: comment
-        if: ${{ steps.apply.outcome == 'success' }}
+        if: ${{ steps.apply.outcome == 'success' && steps.findpr.outputs.pr != '' }}
         uses: actions/github-script@v6.1.0
         env:
           APPLY: "terraform¥n${{ steps.apply.outputs.stdout }}"

--- a/terraform/common/dev/services/ec2.tf
+++ b/terraform/common/dev/services/ec2.tf
@@ -64,7 +64,6 @@ resource "aws_security_group" "this" {
       "119.201.72.35/32",
       "221.110.31.103/32",
       "221.149.51.217/32",
-      "13.209.1.56/29", # TODO: 출처 검증 후 제거 또는 유지 결정
     ]
   }
 
@@ -105,7 +104,7 @@ resource "aws_security_group" "this" {
   }
 
   ingress {
-    description = "Laravel internal nginx (admin from home IP)"
+    description = "Laravel internal nginx (home IP + self-SG)"
     from_port   = 8201
     to_port     = 8201
     protocol    = "tcp"
@@ -114,7 +113,7 @@ resource "aws_security_group" "this" {
   }
 
   ingress {
-    description = "MySQL (admin from home IP)"
+    description = "MySQL (home IP + self-SG)"
     from_port   = 3306
     to_port     = 3306
     protocol    = "tcp"

--- a/terraform/go-jwt/modules/services/codedeploy.tf
+++ b/terraform/go-jwt/modules/services/codedeploy.tf
@@ -1,0 +1,27 @@
+##############################
+# go-jwt CodeDeploy
+##############################
+resource "aws_codedeploy_app" "this" {
+  name             = "go-jwt"
+  compute_platform = "Server"
+}
+
+resource "aws_codedeploy_deployment_group" "this" {
+  app_name               = aws_codedeploy_app.this.name
+  deployment_group_name  = "go-jwt-deploy-group"
+  service_role_arn       = "arn:aws:iam::204207504139:role/ec2_codedeploy"
+  deployment_config_name = "CodeDeployDefault.AllAtOnce"
+
+  ec2_tag_set {
+    ec2_tag_filter {
+      key   = "name"
+      type  = "KEY_AND_VALUE"
+      value = "ec2-server-hkpark"
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITHOUT_TRAFFIC_CONTROL"
+    deployment_type   = "IN_PLACE"
+  }
+}

--- a/terraform/react-intro/modules/services/codedeploy.tf
+++ b/terraform/react-intro/modules/services/codedeploy.tf
@@ -1,0 +1,28 @@
+##############################
+# react-intro CodeDeploy
+# (codepipeline.tf 의 Deploy 단계가 ApplicationName / DeploymentGroupName 로 참조)
+##############################
+resource "aws_codedeploy_app" "this" {
+  name             = "deploy-app"
+  compute_platform = "Server"
+}
+
+resource "aws_codedeploy_deployment_group" "this" {
+  app_name               = aws_codedeploy_app.this.name
+  deployment_group_name  = "react"
+  service_role_arn       = "arn:aws:iam::204207504139:role/ec2_codedeploy"
+  deployment_config_name = "CodeDeployDefault.AllAtOnce"
+
+  ec2_tag_set {
+    ec2_tag_filter {
+      key   = "name"
+      type  = "KEY_AND_VALUE"
+      value = "ec2-server-hkpark"
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITHOUT_TRAFFIC_CONTROL"
+    deployment_type   = "IN_PLACE"
+  }
+}

--- a/terraform/spring-blog/modules/services/codedeploy.tf
+++ b/terraform/spring-blog/modules/services/codedeploy.tf
@@ -1,0 +1,27 @@
+##############################
+# spring-blog CodeDeploy
+##############################
+resource "aws_codedeploy_app" "this" {
+  name             = "spring-blog-deploy"
+  compute_platform = "Server"
+}
+
+resource "aws_codedeploy_deployment_group" "this" {
+  app_name               = aws_codedeploy_app.this.name
+  deployment_group_name  = "spring"
+  service_role_arn       = "arn:aws:iam::204207504139:role/ec2_codedeploy"
+  deployment_config_name = "CodeDeployDefault.AllAtOnce"
+
+  ec2_tag_set {
+    ec2_tag_filter {
+      key   = "name"
+      type  = "KEY_AND_VALUE"
+      value = "ec2-server-hkpark"
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITHOUT_TRAFFIC_CONTROL"
+    deployment_type   = "IN_PLACE"
+  }
+}


### PR DESCRIPTION
…loy import

1) GitHub Actions workflow 의 comment 스텝이 release 직접 push 시 PR 못 찾아
   404 로 실패하던 문제 fix — `steps.findpr.outputs.pr != ''` 가드 추가.
   - .github/workflows/common-dev-apply.yml
   - .github/workflows/project-dev-apply.yml

2) common SG (launch-wizard-1) 정리 follow-up:
   - 8201, 3306 description 을 (home IP + self-SG) 로 보강 (Copilot 리뷰 #6, #7 반영).
   - SSH 22 의 13.209.1.56/29 (출처 미확인 AWS Seoul 대역) 제거.

3) CodeDeploy 앱 / 디플로이먼트 그룹을 terraform 으로 흡수:
   - react-intro/modules/services/codedeploy.tf 신규 (deploy-app + react)
   - spring-blog/modules/services/codedeploy.tf 신규 (spring-blog-deploy + spring)
   - go-jwt/modules/services/codedeploy.tf 신규 (go-jwt + go-jwt-deploy-group)
   - 기존 AWS 자원 6개 import 완료, plan 검증: · default_tags 적용 (Env/Service) — 정상 · react-intro CodePipeline 의 DetectChanges=false 강제 — 콘솔 drift 정상화

별도로 진행한 cleanup (terraform 외부, 본 commit 미포함):
- ami-test SG (sg-055f63bf139ee7e01) 삭제
- 고아 IAM Role 7개 정리 + customer-managed policy 6개 삭제 (HelloWorldFunction-role × 3, ecsTaskExecutionRole, Glue 워크샵, Kinesis us-east-1)
- ecsInstanceRole 만 instance profile 묶임 때문에 follow-up 으로 남음

## PR의 목적



## 관련URL



## 특이사항

